### PR TITLE
Yolo 추론 시 bbox 영역 블러 처리

### DIFF
--- a/MAIN_CODES/YOLO/yolo.py
+++ b/MAIN_CODES/YOLO/yolo.py
@@ -68,10 +68,60 @@ def load_yolo_model(model_path:str = 'yolov8x.pt'):
     model = YOLO(model_path) 
     return model
 
-def run_inference(model, image_path):
+def _clip_bbox_to_image(image, x1, y1, x2, y2):
+    h, w = image.shape[:2]
+    x1 = max(0, min(int(x1), w - 1))
+    y1 = max(0, min(int(y1), h - 1))
+    x2 = max(0, min(int(x2), w))
+    y2 = max(0, min(int(y2), h))
+    # ensure proper ordering
+    if x2 < x1:
+        x1, x2 = x2, x1
+    if y2 < y1:
+        y1, y2 = y2, y1
+    return x1, y1, x2, y2
+
+def _ensure_odd(value:int) -> int:
+    return value if value % 2 == 1 else value + 1
+
+def apply_gaussian_blur_to_boxes(image, boxes, ksize: int = 31, sigmaX: int = 0):
+    processed = image.copy()
+    base_kernel = max(1, _ensure_odd(int(ksize)))
+    for bbox in boxes:
+        x1, y1, x2, y2 = map(int, bbox)
+        x1, y1, x2, y2 = _clip_bbox_to_image(processed, x1, y1, x2, y2)
+        if y2 <= y1 or x2 <= x1:
+            continue
+        region = processed[y1:y2, x1:x2]
+        h, w = region.shape[:2]
+        # Adjust kernel to fit region size while keeping it odd and >= 1
+        k = min(base_kernel, h if h % 2 == 1 else max(1, h - 1), w if w % 2 == 1 else max(1, w - 1))
+        k = max(1, _ensure_odd(k))
+        blurred = cv2.GaussianBlur(region, (k, k), sigmaX)
+        processed[y1:y2, x1:x2] = blurred
+    return processed
+
+def apply_mosaic_to_boxes(image, boxes, block_size: int = 15):
+    processed = image.copy()
+    block_size = max(1, int(block_size))
+    for bbox in boxes:
+        x1, y1, x2, y2 = map(int, bbox)
+        x1, y1, x2, y2 = _clip_bbox_to_image(processed, x1, y1, x2, y2)
+        if y2 <= y1 or x2 <= x1:
+            continue
+        region = processed[y1:y2, x1:x2]
+        h, w = region.shape[:2]
+        small_w = max(1, w // block_size)
+        small_h = max(1, h // block_size)
+        small = cv2.resize(region, (small_w, small_h), interpolation=cv2.INTER_LINEAR)
+        mosaic = cv2.resize(small, (w, h), interpolation=cv2.INTER_NEAREST)
+        processed[y1:y2, x1:x2] = mosaic
+    return processed
+
+def run_inference(model, image_path, postprocess: str = None, blur_ksize: int = 31, mosaic_block_size: int = 15, conf: float = 0.25):
     image = cv2.imread(image_path)
     image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-    results = model(image, conf=0.25)
+    results = model(image, conf=conf)
     bounding_boxes = []
     probabilities = []
     entity_names = []
@@ -86,6 +136,13 @@ def run_inference(model, image_path):
             probabilities.append(score)
             entity_names.append(class_name)
 
+    if postprocess is not None:
+        mode = str(postprocess).lower()
+        if mode in ["blur", "gaussian", "gaussian_blur"]:
+            image = apply_gaussian_blur_to_boxes(image, bounding_boxes, ksize=blur_ksize)
+        elif mode in ["mosaic", "pixelate", "pixelation"]:
+            image = apply_mosaic_to_boxes(image, bounding_boxes, block_size=mosaic_block_size)
+
     return bounding_boxes, probabilities, entity_names, image
 
 def draw_boxes(image, bounding_boxes, probabilities, entity_names):
@@ -98,7 +155,7 @@ def draw_boxes(image, bounding_boxes, probabilities, entity_names):
 
 ##################################################
 
-def main(image_path, model_path):
+def main(image_path, model_path, postprocess=None, output_path=None, blur_ksize: int = 31, mosaic_block_size: int = 15, conf: float = 0.25):
     print(f"욜로 : {model_path}")
 
     if model_path == 'yolov3x.pt': #형식 통일을 위함. 
@@ -115,7 +172,14 @@ def main(image_path, model_path):
     
     elif model_path == 'yolov8x.pt':
         model = load_yolo_model(model_path)
-        bounding_boxes, probabilities, entity_names, image = run_inference(model, image_path)
+        bounding_boxes, probabilities, entity_names, image = run_inference(
+            model,
+            image_path,
+            postprocess=postprocess,
+            blur_ksize=blur_ksize,
+            mosaic_block_size=mosaic_block_size,
+            conf=conf,
+        )
         all = []
         for bbox, prob, name in zip(bounding_boxes, probabilities, entity_names):
             # print(f"Entity: {name}, Probability: {prob:.2f}, Bounding Box: {bbox}")
@@ -126,6 +190,11 @@ def main(image_path, model_path):
             if entity not in unique_items or probability > unique_items[entity]:
                 unique_items[entity] = probability
         result = [(entity, probability) for entity, probability in unique_items.items()]
+        if output_path is not None:
+            # Save the possibly post-processed image
+            bgr = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
+            os.makedirs(os.path.dirname(output_path), exist_ok=True) if os.path.dirname(output_path) else None
+            cv2.imwrite(output_path, bgr)
         
         return result
     else:

--- a/MAIN_CODES/YOLO/yolo.py
+++ b/MAIN_CODES/YOLO/yolo.py
@@ -118,6 +118,16 @@ def apply_mosaic_to_boxes(image, boxes, block_size: int = 15):
         processed[y1:y2, x1:x2] = mosaic
     return processed
 
+def apply_black_mask_to_boxes(image, boxes):
+    processed = image.copy()
+    for bbox in boxes:
+        x1, y1, x2, y2 = map(int, bbox)
+        x1, y1, x2, y2 = _clip_bbox_to_image(processed, x1, y1, x2, y2)
+        if y2 <= y1 or x2 <= x1:
+            continue
+        processed[y1:y2, x1:x2] = 0
+    return processed
+
 def run_inference(model, image_path, postprocess: str = None, blur_ksize: int = 31, mosaic_block_size: int = 15, conf: float = 0.25):
     image = cv2.imread(image_path)
     image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
@@ -142,6 +152,8 @@ def run_inference(model, image_path, postprocess: str = None, blur_ksize: int = 
             image = apply_gaussian_blur_to_boxes(image, bounding_boxes, ksize=blur_ksize)
         elif mode in ["mosaic", "pixelate", "pixelation"]:
             image = apply_mosaic_to_boxes(image, bounding_boxes, block_size=mosaic_block_size)
+        elif mode in ["mask", "blackout", "black"]:
+            image = apply_black_mask_to_boxes(image, bounding_boxes)
 
     return bounding_boxes, probabilities, entity_names, image
 

--- a/MAIN_CODES/decoder_zoo/Woodpecker/contrastive_orchestrator.py
+++ b/MAIN_CODES/decoder_zoo/Woodpecker/contrastive_orchestrator.py
@@ -1,0 +1,100 @@
+import os
+from typing import Tuple, Dict, Any
+from PIL import Image
+import numpy as np
+
+from MAIN_CODES.YOLO.yolo import load_yolo_model, run_inference
+
+
+def save_rgb_image(array: np.ndarray, path: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True) if os.path.dirname(path) else None
+    Image.fromarray(array).save(path)
+
+
+def vlm_infer_blip2(processor, model, image_rgb: np.ndarray, instruction: str) -> str:
+    img = Image.fromarray(image_rgb)
+    inputs = processor(img, instruction, return_tensors="pt").to("cuda", model.config.torch_dtype)
+    generated_ids = model.generate(**inputs)
+    text = processor.decode(generated_ids[0], skip_special_tokens=True)
+    return text.strip()
+
+
+def contrastive_merge(text_a: str, text_b: str) -> str:
+    if text_a == text_b:
+        return text_a
+    if len(text_b) > len(text_a) and text_b.lower() not in text_a.lower():
+        return text_b
+    return text_a
+
+
+def run_contrastive_pipeline(
+    image_path: str,
+    instruction: str,
+    yolo_model_path: str = "yolov8n.pt",
+    postprocess: str = "blur",  # or "mask"/"mosaic"
+    conf: float = 0.25,
+    blur_ksize: int = 31,
+    mosaic_block_size: int = 15,
+    vlm_processor=None,
+    vlm_model=None,
+    save_debug_dir: str = None,
+) -> Dict[str, Any]:
+    yolo = load_yolo_model(yolo_model_path)
+    bboxes, probs, names, img_rgb_processed = run_inference(
+        yolo, image_path, postprocess=postprocess, blur_ksize=blur_ksize, mosaic_block_size=mosaic_block_size, conf=conf
+    )
+    # also get original image without postprocess
+    _, _, _, img_rgb_orig = run_inference(yolo, image_path, postprocess=None, conf=conf)
+
+    if save_debug_dir:
+        save_rgb_image(img_rgb_orig, os.path.join(save_debug_dir, "orig.jpg"))
+        save_rgb_image(img_rgb_processed, os.path.join(save_debug_dir, f"{postprocess}.jpg"))
+
+    # VLM inference on both images
+    assert vlm_processor is not None and vlm_model is not None, "Provide VLM processor and model"
+    text_orig = vlm_infer_blip2(vlm_processor, vlm_model, img_rgb_orig, instruction)
+    text_proc = vlm_infer_blip2(vlm_processor, vlm_model, img_rgb_processed, instruction)
+
+    merged = contrastive_merge(text_orig, text_proc)
+
+    return {
+        "bboxes": bboxes,
+        "probs": probs,
+        "names": names,
+        "text_original": text_orig,
+        "text_processed": text_proc,
+        "merged_text": merged,
+    }
+
+
+if __name__ == "__main__":
+    import argparse
+    import torch
+    from transformers import Blip2Processor, Blip2ForConditionalGeneration
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--instruction", required=True)
+    parser.add_argument("--yolo", default="yolov8n.pt")
+    parser.add_argument("--postprocess", default="blur")
+    parser.add_argument("--conf", type=float, default=0.25)
+    parser.add_argument("--save_debug_dir", default=None)
+    args = parser.parse_args()
+
+    processor = Blip2Processor.from_pretrained("Salesforce/blip2-flan-t5-xxl")
+    device_map = {"query_tokens": 0, "vision_model": 0, "language_model": 0, "language_projection": 0, "qformer": 0}
+    model = Blip2ForConditionalGeneration.from_pretrained(
+        "Salesforce/blip2-flan-t5-xxl", load_in_8bit=True, device_map=device_map, torch_dtype=torch.float16
+    )
+
+    out = run_contrastive_pipeline(
+        image_path=args.image,
+        instruction=args.instruction,
+        yolo_model_path=args.yolo,
+        postprocess=args.postprocess,
+        conf=args.conf,
+        vlm_processor=processor,
+        vlm_model=model,
+        save_debug_dir=args.save_debug_dir,
+    )
+    print(out["merged_text"]) 

--- a/YOLO_Contrastive_VLM.ipynb
+++ b/YOLO_Contrastive_VLM.ipynb
@@ -1,3 +1,164 @@
+# LLAVA-style logit-based contrastive decoding (RVCD-like)
+# Note: Requires a HF LLaVA model that supports pixel_values + generate/forward with use_cache.
+
+from transformers import AutoProcessor, LlavaForConditionalGeneration
+import torch.nn.functional as F
+
+
+def load_llava(model_id: str = "liuhaotian/llava-v1.5-7b-hf", dtype=torch.float16, device: str = "cuda"):
+    processor = AutoProcessor.from_pretrained(model_id)
+    model = LlavaForConditionalGeneration.from_pretrained(
+        model_id,
+        torch_dtype=dtype,
+        device_map="auto",
+    )
+    return processor, model
+
+
+def _prepare_llava_inputs(processor, image_rgb: np.ndarray, prompt: str, device: str = "cuda"):
+    image = Image.fromarray(image_rgb)
+    proc = processor(images=image, text=prompt, return_tensors="pt")
+    proc = {k: v.to(device) for k, v in proc.items()}
+    return proc
+
+
+def _step_logits_llava(model, inputs: Dict[str, torch.Tensor], past_kv=None):
+    # If past_kv provided, feed only last token; else full prompt
+    if past_kv is not None:
+        # keep only last token for incremental step
+        inputs_step = {
+            "input_ids": inputs["input_ids"][:, -1:],
+            "attention_mask": inputs.get("attention_mask", None),
+            "pixel_values": inputs.get("pixel_values", None),
+            "past_key_values": past_kv,
+            "use_cache": True,
+        }
+    else:
+        inputs_step = {
+            "input_ids": inputs["input_ids"],
+            "attention_mask": inputs.get("attention_mask", None),
+            "pixel_values": inputs.get("pixel_values", None),
+            "use_cache": True,
+        }
+    outputs = model(**{k: v for k, v in inputs_step.items() if v is not None}, output_hidden_states=False)
+    logits = outputs.logits[:, -1, :]
+    return logits, outputs.past_key_values
+
+
+def _append_token(inputs: Dict[str, torch.Tensor], token_id: int):
+    token = torch.tensor([[token_id]], device=inputs["input_ids"].device)
+    inputs["input_ids"] = torch.cat([inputs["input_ids"], token], dim=1)
+    if "attention_mask" in inputs and inputs["attention_mask"] is not None:
+        inputs["attention_mask"] = torch.cat([inputs["attention_mask"], torch.ones_like(token)], dim=1)
+    return inputs
+
+
+def rvcd_adjust_logits(original_logit, negative_logits: List[torch.Tensor], positive_logits: List[torch.Tensor], alpha: float, beta: float):
+    neg_c = len(negative_logits)
+    pos_c = len(positive_logits)
+    sum_neg = sum(negative_logits) if neg_c > 0 else 0
+    sum_pos = sum(positive_logits) if pos_c > 0 else 0
+    adjusted = (1 + alpha * neg_c - beta * pos_c) * original_logit - (alpha * sum_neg - beta * sum_pos)
+    return adjusted
+
+
+def llava_contrastive_decode(
+    processor,
+    model,
+    prompt: str,
+    img_original_rgb: np.ndarray,
+    img_negative_rgbs: List[np.ndarray],
+    img_positive_rgbs: List[np.ndarray],
+    alpha: float = 1.0,
+    beta: float = 0.1,
+    gamma: float = 0.0,
+    max_new_tokens: int = 64,
+    device: str = "cuda",
+):
+    # Prepare inputs for original/negatives/positives
+    inp_orig = _prepare_llava_inputs(processor, img_original_rgb, prompt, device)
+    inps_neg = [_prepare_llava_inputs(processor, img, prompt, device) for img in img_negative_rgbs]
+    inps_pos = [_prepare_llava_inputs(processor, img, prompt, device) for img in img_positive_rgbs]
+
+    generated = []
+    pkv_orig = pkv_negs = pkv_pos = None
+    # Initialize past_kv by running first forward on the full prompt per stream
+    orig_logit, pkv_orig = _step_logits_llava(model, inp_orig, past_kv=None)
+    neg_logits_first, pos_logits_first = [], []
+    pkv_negs = []
+    for inp in inps_neg:
+        lg, pkv = _step_logits_llava(model, inp, past_kv=None)
+        neg_logits_first.append(lg)
+        pkv_negs.append(pkv)
+    pkv_pos = []
+    for inp in inps_pos:
+        lg, pkv = _step_logits_llava(model, inp, past_kv=None)
+        pos_logits_first.append(lg)
+        pkv_pos.append(pkv)
+
+    # Adjust and pick first token
+    adjusted = rvcd_adjust_logits(orig_logit, neg_logits_first, pos_logits_first, alpha, beta)
+    orig_probs = F.softmax(orig_logit, dim=-1)
+    probs = F.softmax(adjusted, dim=-1)
+    if gamma > 0:
+        threshold = gamma * torch.max(orig_probs)
+        low_idx = torch.where(orig_probs < threshold)[1] if orig_probs.ndim == 2 else torch.where(orig_probs < threshold)[0]
+        probs[..., low_idx] = 0
+    next_id = int(torch.argmax(probs, dim=-1).item())
+    generated.append(next_id)
+
+    # Loop for remaining tokens using past_key_values and feeding only last token
+    for _ in range(max_new_tokens - 1):
+        # append token to each input stream
+        _append_token(inp_orig, next_id)
+        neg_logits, pos_logits = [], []
+        orig_logit, pkv_orig = _step_logits_llava(model, inp_orig, past_kv=pkv_orig)
+        for i, inp in enumerate(inps_neg):
+            _append_token(inp, next_id)
+            lg, pkv_negs[i] = _step_logits_llava(model, inp, past_kv=pkv_negs[i])
+            neg_logits.append(lg)
+        pos_logits = []
+        for i, inp in enumerate(inps_pos):
+            _append_token(inp, next_id)
+            lg, pkv_pos[i] = _step_logits_llava(model, inp, past_kv=pkv_pos[i])
+            pos_logits.append(lg)
+
+        adjusted = rvcd_adjust_logits(orig_logit, neg_logits, pos_logits, alpha, beta)
+        orig_probs = F.softmax(orig_logit, dim=-1)
+        probs = F.softmax(adjusted, dim=-1)
+        if gamma > 0:
+            threshold = gamma * torch.max(orig_probs)
+            low_idx = torch.where(orig_probs < threshold)[1] if orig_probs.ndim == 2 else torch.where(orig_probs < threshold)[0]
+            probs[..., low_idx] = 0
+        next_id = int(torch.argmax(probs, dim=-1).item())
+        generated.append(next_id)
+        if next_id == model.config.eos_token_id:
+            break
+
+    return generated  # token ids; decode with model's tokenizer/processor
+
+
+# Convenience wrapper using YOLO-processed image as a single negative stream
+
+def llava_cd_with_yolo(processor, model, prompt: str, image_path: str, postprocess: str = "mask", conf: float = 0.25, yolo_model: str = "yolov8n.pt", alpha: float = 1.0, beta: float = 0.1, gamma: float = 0.0, max_new_tokens: int = 64, device: str = "cuda"):
+    boxes, probs, names, img_orig = yolo_detect(image_path, yolo_model, conf)
+    img_neg = postprocess_image(img_orig, boxes, postprocess)
+    token_ids = llava_contrastive_decode(
+        processor,
+        model,
+        prompt,
+        img_orig,
+        [img_neg],  # negative list
+        [],         # positive list
+        alpha=alpha,
+        beta=beta,
+        gamma=gamma,
+        max_new_tokens=max_new_tokens,
+        device=device,
+    )
+    # decode tokens
+    text = model.get_decoder().tokenizer.decode(token_ids, skip_special_tokens=True) if hasattr(model, "get_decoder") else processor.tokenizer.decode(token_ids, skip_special_tokens=True)
+    return text
 import os
 from typing import Dict, Any, List
 import numpy as np

--- a/YOLO_Contrastive_VLM.ipynb
+++ b/YOLO_Contrastive_VLM.ipynb
@@ -1,0 +1,149 @@
+import os
+from typing import Dict, Any, List
+import numpy as np
+import cv2
+from PIL import Image
+
+from ultralytics import YOLO
+from transformers import Blip2Processor, Blip2ForConditionalGeneration
+import torch
+
+# --- YOLO postprocess utilities ---
+
+def _clip_bbox_to_image(image: np.ndarray, x1: int, y1: int, x2: int, y2: int):
+    h, w = image.shape[:2]
+    x1 = max(0, min(int(x1), w - 1))
+    y1 = max(0, min(int(y1), h - 1))
+    x2 = max(0, min(int(x2), w))
+    y2 = max(0, min(int(y2), h))
+    if x2 < x1:
+        x1, x2 = x2, x1
+    if y2 < y1:
+        y1, y2 = y2, y1
+    return x1, y1, x2, y2
+
+def _ensure_odd(value: int) -> int:
+    return value if value % 2 == 1 else value + 1
+
+def apply_gaussian_blur_to_boxes(image: np.ndarray, boxes: List[List[float]], ksize: int = 31, sigmaX: int = 0):
+    processed = image.copy()
+    base_kernel = max(1, _ensure_odd(int(ksize)))
+    for bbox in boxes:
+        x1, y1, x2, y2 = map(int, bbox)
+        x1, y1, x2, y2 = _clip_bbox_to_image(processed, x1, y1, x2, y2)
+        if y2 <= y1 or x2 <= x1:
+            continue
+        region = processed[y1:y2, x1:x2]
+        h, w = region.shape[:2]
+        k = min(base_kernel, h if h % 2 == 1 else max(1, h - 1), w if w % 2 == 1 else max(1, w - 1))
+        k = max(1, _ensure_odd(k))
+        blurred = cv2.GaussianBlur(region, (k, k), sigmaX)
+        processed[y1:y2, x1:x2] = blurred
+    return processed
+
+def apply_mosaic_to_boxes(image: np.ndarray, boxes: List[List[float]], block_size: int = 15):
+    processed = image.copy()
+    block_size = max(1, int(block_size))
+    for bbox in boxes:
+        x1, y1, x2, y2 = map(int, bbox)
+        x1, y1, x2, y2 = _clip_bbox_to_image(processed, x1, y1, x2, y2)
+        if y2 <= y1 or x2 <= x1:
+            continue
+        region = processed[y1:y2, x1:x2]
+        h, w = region.shape[:2]
+        small_w = max(1, w // block_size)
+        small_h = max(1, h // block_size)
+        small = cv2.resize(region, (small_w, small_h), interpolation=cv2.INTER_LINEAR)
+        mosaic = cv2.resize(small, (w, h), interpolation=cv2.INTER_NEAREST)
+        processed[y1:y2, x1:x2] = mosaic
+    return processed
+
+def apply_black_mask_to_boxes(image: np.ndarray, boxes: List[List[float]]):
+    processed = image.copy()
+    for bbox in boxes:
+        x1, y1, x2, y2 = map(int, bbox)
+        x1, y1, x2, y2 = _clip_bbox_to_image(processed, x1, y1, x2, y2)
+        if y2 <= y1 or x2 <= x1:
+            continue
+        processed[y1:y2, x1:x2] = 0
+    return processed
+
+# --- YOLO inference ---
+
+def yolo_detect(image_path: str, model_path: str = "yolov8n.pt", conf: float = 0.25):
+    model = YOLO(model_path)
+    image_bgr = cv2.imread(image_path)
+    image_rgb = cv2.cvtColor(image_bgr, cv2.COLOR_BGR2RGB)
+    results = model(image_rgb, conf=conf)
+    boxes, probs, names = [], [], []
+    for result in results:
+        for box in result.boxes:
+            bbox = box.xyxy[0].tolist()
+            score = box.conf[0].item()
+            cls_id = int(box.cls[0].item())
+            boxes.append(bbox)
+            probs.append(score)
+            names.append(model.names[cls_id])
+    return boxes, probs, names, image_rgb
+
+def postprocess_image(image_rgb: np.ndarray, boxes: List[List[float]], mode: str, blur_ksize: int = 31, mosaic_block_size: int = 15):
+    m = (mode or "").lower()
+    if m in ("blur", "gaussian", "gaussian_blur"):
+        return apply_gaussian_blur_to_boxes(image_rgb, boxes, ksize=blur_ksize)
+    if m in ("mosaic", "pixelate", "pixelation"):
+        return apply_mosaic_to_boxes(image_rgb, boxes, block_size=mosaic_block_size)
+    if m in ("mask", "blackout", "black"):
+        return apply_black_mask_to_boxes(image_rgb, boxes)
+    return image_rgb
+
+# --- VLM inference (BLIP2 example) ---
+
+def load_vlm(model_id: str = "Salesforce/blip2-flan-t5-xxl"):
+    processor = Blip2Processor.from_pretrained(model_id)
+    device_map = {"query_tokens": 0, "vision_model": 0, "language_model": 0, "language_projection": 0, "qformer": 0}
+    model = Blip2ForConditionalGeneration.from_pretrained(model_id, load_in_8bit=True, device_map=device_map, torch_dtype=torch.float16)
+    return processor, model
+
+def vlm_infer(processor, model, image_rgb: np.ndarray, instruction: str) -> str:
+    img = Image.fromarray(image_rgb)
+    inputs = processor(img, instruction, return_tensors="pt").to("cuda", torch.float16)
+    with torch.no_grad():
+        generated = model.generate(**inputs)
+    return processor.decode(generated[0], skip_special_tokens=True).strip()
+
+# --- Contrastive merge ---
+
+def contrastive_merge(text_a: str, text_b: str) -> str:
+    if text_a == text_b:
+        return text_a
+    if len(text_b) > len(text_a) and text_b.lower() not in text_a.lower():
+        return text_b
+    return text_a
+
+# --- Orchestrator ---
+
+def contrastive_pipeline(image_path: str, instruction: str, postprocess: str = "blur", yolo_model: str = "yolov8n.pt", conf: float = 0.25, blur_ksize: int = 31, mosaic_block_size: int = 15, processor=None, model=None) -> Dict[str, Any]:
+    boxes, probs, names, img_orig = yolo_detect(image_path, yolo_model, conf)
+    img_proc = postprocess_image(img_orig, boxes, postprocess, blur_ksize, mosaic_block_size)
+
+    if processor is None or model is None:
+        processor, model = load_vlm()
+
+    text_orig = vlm_infer(processor, model, img_orig, instruction)
+    text_proc = vlm_infer(processor, model, img_proc, instruction)
+    merged = contrastive_merge(text_orig, text_proc)
+
+    return {
+        "bboxes": boxes,
+        "probs": probs,
+        "names": names,
+        "text_original": text_orig,
+        "text_processed": text_proc,
+        "merged_text": merged,
+    }
+
+# --- Example usage (uncomment to run) ---
+# image_path = "/path/to/your.jpg"
+# instruction = "Describe the image."
+# out = contrastive_pipeline(image_path, instruction, postprocess="mask")
+# print(out["merged_text"]) 


### PR DESCRIPTION
Add Gaussian blur and mosaic post-processing options to YOLO inference to obscure detected bounding box regions.

---
<a href="https://cursor.com/background-agent?bcId=bc-9757f534-cf9a-43c3-9e9b-a7f30b2f47fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9757f534-cf9a-43c3-9e9b-a7f30b2f47fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

